### PR TITLE
Add the ability to skip purging during development

### DIFF
--- a/bin/purgesvg
+++ b/bin/purgesvg
@@ -30,6 +30,11 @@ yargsBin = yargs
         type: 'array',
         default: []
     })
+    .option('d', {
+        alias: 'dev',
+        description: 'Skip purging during development',
+        type: 'boolean',
+    })
     .demandCommand(0)
     .help()
     .alias('h', 'help')
@@ -38,7 +43,7 @@ yargsBin = yargs
 argv = yargs.argv
 
 if (argv.config) {
-    new PurgeSVG(argv.config).purge()
+    new PurgeSVG(argv).purge()
     return
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,11 @@ const flatten = (arr, initialVal) => [...arr, ...initialVal]
 
 class PurgeSvg {
     constructor (options) {
-        if (typeof options === 'string' || typeof options === 'undefined') {
-            options = PurgeSvg.loadConfigFile(options)
+        if (options.config) {
+            const dev = options.dev
+            options = PurgeSvg.loadConfigFile(options.config)
+            if (dev) options.dev = dev
+            else if (options.env === 'dev') options.dev = true
         }
 
         PurgeSvg.validateOptions(options)
@@ -159,9 +162,14 @@ class PurgeSvg {
                 outSvgs[svgObj.out] = []
             }
 
-            outSvgs[svgObj.out].push(
-                ...symbols.filter((s) => ids.has(s._attributes.id)),
-            )
+            if (this.options.dev){
+                outSvgs[svgObj.out].push(...symbols)
+            }
+            else{
+                outSvgs[svgObj.out].push(
+                    ...symbols.filter((s) => ids.has(s._attributes.id)),
+                )
+            }
         })
 
         for (let filename in outSvgs) {


### PR DESCRIPTION
In dev environments I would like to have all icons and styles available, so I set my dev scripts to skip things like minification, purging etc.

To this end I added a -d and --dev flag to the CLI to skip purging.

Changed how the options are passed since the flag was getting lost when loading a config file.

Added a new key value pair of env: 'dev' to the config file in case people want to set it that way.  It defaults to env: 'production'